### PR TITLE
Add Akka.Discovery.Config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,6 +299,10 @@ paket-files/
 # FAKE - F# Make
 .fake/
 
+# JetBrains Rider
+.idea/
+*.sln.iml
+
 # CodeRush personal settings
 .cr/personal
 

--- a/src/WebApiTemplate/.gitignore
+++ b/src/WebApiTemplate/.gitignore
@@ -2,7 +2,6 @@
 tools/
 .nuget/
 .dotnet/
-.idea/
 .[Dd][Ss]_[Ss]tore
 
 ## NBench output

--- a/src/WebApiTemplate/Directory.Packages.props
+++ b/src/WebApiTemplate/Directory.Packages.props
@@ -5,13 +5,13 @@
 
   <!-- Akka.NET Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="Akka" Version="1.5.6" />
-    <PackageVersion Include="Akka.Cluster.Hosting" Version="1.5.6" />
-    <PackageVersion Include="Akka.Discovery.Azure" Version="1.5.5" />
+    <PackageVersion Include="Akka" Version="1.5.7" />
+    <PackageVersion Include="Akka.Cluster.Hosting" Version="1.5.7" />
+    <PackageVersion Include="Akka.Discovery.Azure" Version="1.5.7" />
     <PackageVersion Include="Akka.HealthCheck.Hosting.Web" Version="1.5.2" />
-    <PackageVersion Include="Akka.Management" Version="1.5.5" />
+    <PackageVersion Include="Akka.Management" Version="1.5.7" />
     <PackageVersion Include="Akka.Persistence.Azure.Hosting" Version="1.5.1" />
-    <PackageVersion Include="Microsoft.NET.Build.Containers" Version="0.4.0" />
+    <PackageVersion Include="Microsoft.NET.Build.Containers" Version="7.0.302" />
     <PackageVersion Include="Petabridge.Cmd.Cluster.Sharding" Version="$(PbmVersion)" />
     <PackageVersion Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />
     <PackageVersion Include="Petabridge.Cmd.Remote" Version="$(PbmVersion)" />
@@ -26,11 +26,11 @@
 
   <!-- Test Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageVersion Include="FluentAssertions" Version="6.11.0" />
-    <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="Akka.Hosting.TestKit" Version="1.5.6" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Akka.Hosting.TestKit" Version="1.5.7" />
   </ItemGroup>
 </Project>

--- a/src/WebApiTemplate/src/WebApiTemplate.App/Configuration/AkkaConfiguration.cs
+++ b/src/WebApiTemplate/src/WebApiTemplate.App/Configuration/AkkaConfiguration.cs
@@ -4,6 +4,7 @@ using Akka.Cluster.Hosting;
 using Akka.Cluster.Sharding;
 using Akka.Configuration;
 using Akka.Discovery.Azure;
+using Akka.Discovery.Config.Hosting;
 using Akka.Hosting;
 using Akka.Management;
 using Akka.Management.Cluster.Bootstrap;
@@ -99,7 +100,21 @@ public static class AkkaConfiguration
                     break;
                 }
                 case DiscoveryMethod.Config:
+                {
+                    b = b
+                        .WithConfigDiscovery(options =>
+                        {
+                            options.Services.Add(new Service
+                            {
+                                Name = settings.AkkaManagementOptions.ServiceName,
+                                Endpoints = new[]
+                                {
+                                    $"{settings.AkkaManagementOptions.Hostname}:{settings.AkkaManagementOptions.Port}",
+                                }
+                            });
+                        });
                     break;
+                }
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/src/WebApiTemplate/src/WebApiTemplate.App/WebApiTemplate.App.csproj
+++ b/src/WebApiTemplate/src/WebApiTemplate.App/WebApiTemplate.App.csproj
@@ -32,12 +32,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Content Include="..\.dockerignore">
-        <Link>.dockerignore</Link>
-      </Content>
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\WebApiTemplate.Domain\WebApiTemplate.Domain.csproj" />
     </ItemGroup>
 

--- a/src/WebApiTemplate/src/WebApiTemplate.App/appsettings.json
+++ b/src/WebApiTemplate/src/WebApiTemplate.App/appsettings.json
@@ -24,10 +24,11 @@
       "Role": "web-api"
     },
     "AkkaManagementOptions": {
-      "Enabled": false,
+      "Enabled": true,
+      "Hostname": "localhost",
       "PortName": "management",
       "ServiceName": "akka-management",
-      "RequiredContactPointsNr": 3,
+      "RequiredContactPointsNr": 1,
       "DiscoveryMethod": "Config"
     },
     "PersistenceMode": "InMemory"


### PR DESCRIPTION
Fixes #80

## Changes

* Add Akka.Discovery.Config support for `Default` run configuration
* Update Akka to 1.5.7
* Update Akka.Cluster.Hosting to 1.5.7
* Update Akka.Discovery.Azure to 1.5.7
* Update Akka.Management to 1.5.7
* Update Microsoft.NET.Build.Containers to 7.0.302
* Update Akka.Hosting.TestKit to 1.5.7