### PR TITLE
v0.2.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,5 @@
-## [0.1.5] / 23 August 2023
+## [0.2.0] / 10 January 2024
 
-* Upgraded to [Akka.NET v1.5.12](https://github.com/akkadotnet/akka.net/releases/tag/1.5.12)
-* Upgraded to [Akka.Hosting v1.5.12](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12)
-* [Bump Akka.HealthCheck.Hosting.Web to 1.5.9](https://github.com/akkadotnet/akkadotnet-templates/pull/124)
-* [Bump Petabridge.Cmd to 1.3.2](https://github.com/akkadotnet/akkadotnet-templates/pull/123)
-* [Bump Microsoft.AspNetCore.OpenApi to 7.0.10](https://github.com/akkadotnet/akkadotnet-templates/pull/136)
-* [Bump Microsoft.NET.Build.Containers to 7.0.400](https://github.com/akkadotnet/akkadotnet-templates/pull/137)
-* [Bump xunit to 2.5.0](https://github.com/akkadotnet/akkadotnet-templates/pull/136)
+* Upgraded to [Akka.NET v1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.12)
+* Upgraded to [Akka.Hosting v1.5.15](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12)
+* All templates now include [Akka.Analyzers](https://getakka.net/articles/debugging/akka-analyzers.html) support for finding Akka.NET programming errors at compilation.


### PR DESCRIPTION
## [0.2.0] / 10 January 2024

* Upgraded to [Akka.NET v1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.12)
* Upgraded to [Akka.Hosting v1.5.15](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12)
* All templates now include [Akka.Analyzers](https://getakka.net/articles/debugging/akka-analyzers.html) support for finding Akka.NET programming errors at compilation.