### PR TITLE
Bump all templates and build system to use net8.0

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
+            8.0.x
           global-json-file: "./global.json"
       - name: "dotnet pack"
         run: dotnet pack -c Release
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
+            8.0.x
           global-json-file: "./global.json"
       - name: "dotnet build"
         run: dotnet build -c Release
@@ -71,7 +71,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
+            8.0.x
           global-json-file: "./global.json"
       - name: "dotnet docker"
         run: dotnet publish --os linux --arch x64 -c Release -p:PublishProfile=DefaultContainer

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "7.0.100"
+    "version": "8.0.101"
   }
 }

--- a/src/AkkaConsoleTemplate/.github/workflows/pr_validation.yaml
+++ b/src/AkkaConsoleTemplate/.github/workflows/pr_validation.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-dotnet@v2.1.0
         with:
           dotnet-version: |
-            7.0.x
+            8.0.x
           global-json-file: "./global.json"
 
       - name: "dotnet build"

--- a/src/AkkaConsoleTemplate/Directory.Build.props
+++ b/src/AkkaConsoleTemplate/Directory.Build.props
@@ -12,6 +12,6 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Dependencies">
-        <PbmVersion>1.3.0</PbmVersion>
+        <PbmVersion>1.3.3</PbmVersion>
     </PropertyGroup>
 </Project>

--- a/src/AkkaConsoleTemplate/Directory.Build.props
+++ b/src/AkkaConsoleTemplate/Directory.Build.props
@@ -12,6 +12,6 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Dependencies">
-        <PbmVersion>1.3.3</PbmVersion>
+        <PbmVersion>1.4.0</PbmVersion>
     </PropertyGroup>
 </Project>

--- a/src/AkkaConsoleTemplate/global.json
+++ b/src/AkkaConsoleTemplate/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "7.0.100"
+    "version": "8.0.101"
   }
 }

--- a/src/AkkaConsoleTemplate/src/AkkaConsoleTemplate.App/AkkaConsoleTemplate.App.csproj
+++ b/src/AkkaConsoleTemplate/src/AkkaConsoleTemplate.App/AkkaConsoleTemplate.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/AkkaStreamsTemplate/.github/workflows/pr_validation.yaml
+++ b/src/AkkaStreamsTemplate/.github/workflows/pr_validation.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-dotnet@v2.1.0
         with:
           dotnet-version: |
-            7.0.x
+            8.0.x
           global-json-file: "./global.json"
 
       - name: "dotnet build"

--- a/src/AkkaStreamsTemplate/Directory.Build.props
+++ b/src/AkkaStreamsTemplate/Directory.Build.props
@@ -12,6 +12,6 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Dependencies">
-        <PbmVersion>1.3.0</PbmVersion>
+        <PbmVersion>1.3.3</PbmVersion>
     </PropertyGroup>
 </Project>

--- a/src/AkkaStreamsTemplate/Directory.Build.props
+++ b/src/AkkaStreamsTemplate/Directory.Build.props
@@ -12,6 +12,6 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Dependencies">
-        <PbmVersion>1.3.3</PbmVersion>
+        <PbmVersion>1.4.0</PbmVersion>
     </PropertyGroup>
 </Project>

--- a/src/AkkaStreamsTemplate/global.json
+++ b/src/AkkaStreamsTemplate/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "7.0.100"
+    "version": "8.0.101"
   }
 }

--- a/src/AkkaStreamsTemplate/src/AkkaStreamsTemplate.App/AkkaStreamsTemplate.App.csproj
+++ b/src/AkkaStreamsTemplate/src/AkkaStreamsTemplate.App/AkkaStreamsTemplate.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/WebApiTemplate/.github/workflows/pr_validation.yaml
+++ b/src/WebApiTemplate/.github/workflows/pr_validation.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-dotnet@v2.1.0
         with:
           dotnet-version: |
-            7.0.x
+            8.0.x
           global-json-file: "./global.json"
 
       - name: "dotnet build"
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-dotnet@v2.1.0
         with:
           dotnet-version: |
-            7.0.x
+            8.0.x
           global-json-file: "./global.json"
 
       - name: "dotnet docker"

--- a/src/WebApiTemplate/Directory.Build.props
+++ b/src/WebApiTemplate/Directory.Build.props
@@ -12,6 +12,6 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Dependencies">
-        <PbmVersion>1.3.3</PbmVersion>
+        <PbmVersion>1.4.0</PbmVersion>
     </PropertyGroup>
 </Project>

--- a/src/WebApiTemplate/Directory.Packages.props
+++ b/src/WebApiTemplate/Directory.Packages.props
@@ -19,7 +19,7 @@
 
   <!-- ASP.NET Core Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.15" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
   </ItemGroup>

--- a/src/WebApiTemplate/global.json
+++ b/src/WebApiTemplate/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMinor",
-    "version": "7.0.100"
+    "version": "8.0.101"
   }
 }

--- a/src/WebApiTemplate/src/WebApiTemplate.App/WebApiTemplate.App.csproj
+++ b/src/WebApiTemplate/src/WebApiTemplate.App/WebApiTemplate.App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/WebApiTemplate/src/WebApiTemplate.App/WebApiTemplate.App.csproj
+++ b/src/WebApiTemplate/src/WebApiTemplate.App/WebApiTemplate.App.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-        <ContainerImageName>webpapitemplate-app</ContainerImageName>
+        <ContainerRepository>webpapitemplate-app</ContainerRepository>
         <ContainerImageTags>$(VersionPrefix);latest</ContainerImageTags>
     </PropertyGroup>
 
@@ -24,7 +24,6 @@
         <PackageReference Include="Akka.Management" />
         <PackageReference Include="Akka.Persistence.Azure.Hosting" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-        <PackageReference Include="Microsoft.NET.Build.Containers" />
         <PackageReference Include="Petabridge.Cmd.Cluster" />
         <PackageReference Include="Petabridge.Cmd.Cluster.Sharding" />
         <PackageReference Include="Petabridge.Cmd.Remote" />

--- a/src/WebApiTemplate/src/WebApiTemplate.Domain/WebApiTemplate.Domain.csproj
+++ b/src/WebApiTemplate/src/WebApiTemplate.Domain/WebApiTemplate.Domain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/WebApiTemplate/tests/WebApiTemplate.App.Tests/WebApiTemplate.App.Tests.csproj
+++ b/src/WebApiTemplate/tests/WebApiTemplate.App.Tests/WebApiTemplate.App.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Changes

- Bump github script SDK version to v8.0.x
- Bump all global.json to use v8.0.101
- Bump all templates .csproj to target net8.0
- Make sure all templates are targetting Petabridge.Cmd v1.4.0
- Fix Microsoft.NET.Build.Containers changes between 7.x and 8.x