### PR TITLE
Update RELEASE_NOTES.md for 0.3.0 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-## [0.2.0] / 10 January 2024
+## [0.3.0] / 12 January 2024
 
-* Upgraded to [Akka.NET v1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.12)
-* Upgraded to [Akka.Hosting v1.5.15](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.12)
-* All templates now include [Akka.Analyzers](https://getakka.net/articles/debugging/akka-analyzers.html) support for finding Akka.NET programming errors at compilation.
+* Upgraded to [Akka.Hosting.TestKit v1.5.15](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.15)
+* Upgraded to [Akka.Discovery.Azure v1.5.15](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.15)
+* Upgraded to [Akka.Management v1.5.15](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.15)
+* [Upgraded all templates framework target to net8.0](https://github.com/akkadotnet/akkadotnet-templates/pull/201)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,4 +3,5 @@
 * Upgraded to [Akka.Hosting.TestKit v1.5.15](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.15)
 * Upgraded to [Akka.Discovery.Azure v1.5.15](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.15)
 * Upgraded to [Akka.Management v1.5.15](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.15)
+* [Fix all AK2001 build warnings](https://github.com/akkadotnet/akkadotnet-templates/pull/200)
 * [Upgraded all templates framework target to net8.0](https://github.com/akkadotnet/akkadotnet-templates/pull/201)


### PR DESCRIPTION
## [0.3.0] / 12 January 2024

* Upgraded to [Akka.Hosting.TestKit v1.5.15](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.15)
* Upgraded to [Akka.Discovery.Azure v1.5.15](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.15)
* Upgraded to [Akka.Management v1.5.15](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.15)
* [Fix all AK2001 build warnings](https://github.com/akkadotnet/akkadotnet-templates/pull/200)
* [Upgraded all templates framework target to net8.0](https://github.com/akkadotnet/akkadotnet-templates/pull/201)
