### PR TITLE
Update RELEASE_NOTES.md for 0.3.2 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,13 @@
-## [0.3.1] / March 4 2024
+## [0.3.2] / June 13 2024
 
-* [Update `Akka.Persistence.Azure` setup code](https://github.com/akkadotnet/akkadotnet-templates/pull/223)
-* Upgraded to [Akka v1.5.17.1](https://github.com/akkadotnet/akka.net/releases/tag/1.5.17.1)
-* Upgraded to [Akka.Cluster.Hosting v1.5.17.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.17.1)
-* Upgraded to [Akka.Hosting.TestKit v1.5.17.1](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.17.1)
-* Upgraded to [Akka.Management v1.5.17.1](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.17.1)
-* Upgraded to [Akka.Discovery.Azure v1.5.17.1](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.17.1)
-* Upgraded to [Akka.HealthCheck v1.5.17.1](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/1.5.17.1)
-* Upgraded to [Akka.Persistence.Azure.Hosting v1.5.17.1](https://github.com/petabridge/Akka.Persistence.Azure/releases/tag/1.5.17.1)
-* Upgraded to [Microsoft.NET.Build.Containers v8.0.200](https://github.com/akkadotnet/akkadotnet-templates/pull/222)
+* Upgraded to [Akka v1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
+* Upgraded to [Akka.Cluster.Hosting v1.5.24](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.24)
+* Upgraded to [Akka.Hosting.TestKit v1.5.24](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.24)
+* Upgraded to [Akka.Management v1.5.24](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.24)
+* Upgraded to [Akka.Discovery.Azure v1.5.24](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.24)
+* Upgraded to [Akka.HealthCheck v1.5.24](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/1.5.24)
+* Upgraded to [Akka.HealthCheck.Hosting.Web v1.5.24](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/1.5.24)
+* Upgraded to [Akka.Persistence.Azure.Hosting v1.5.19](https://github.com/petabridge/Akka.Persistence.Azure/releases/tag/1.5.19)
+* Upgraded to [Petabridge.Cmd v1.4.2](https://github.com/petabridge/petabridge.cmd/releases/tag/1.4.2)
+* Upgraded to [Swashbuckle.AspNetCore v6.6.2](https://github.com/akkadotnet/akkadotnet-templates/pull/258)
+* Upgraded to [Microsoft.AspNetCore.OpenApi v8.0.6](https://github.com/akkadotnet/akkadotnet-templates/pull/262)


### PR DESCRIPTION
## [0.3.2] / June 13 2024

* Upgraded to [Akka v1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
* Upgraded to [Akka.Cluster.Hosting v1.5.24](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.24)
* Upgraded to [Akka.Hosting.TestKit v1.5.24](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.24)
* Upgraded to [Akka.Management v1.5.24](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.24)
* Upgraded to [Akka.Discovery.Azure v1.5.24](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.24)
* Upgraded to [Akka.HealthCheck v1.5.24](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/1.5.24)
* Upgraded to [Akka.HealthCheck.Hosting.Web v1.5.24](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/1.5.24)
* Upgraded to [Akka.Persistence.Azure.Hosting v1.5.19](https://github.com/petabridge/Akka.Persistence.Azure/releases/tag/1.5.19)
* Upgraded to [Petabridge.Cmd v1.4.2](https://github.com/petabridge/petabridge.cmd/releases/tag/1.4.2)
* Upgraded to [Swashbuckle.AspNetCore v6.6.2](https://github.com/akkadotnet/akkadotnet-templates/pull/258)
* Upgraded to [Microsoft.AspNetCore.OpenApi v8.0.6](https://github.com/akkadotnet/akkadotnet-templates/pull/262)
