### PR TITLE
Added v0.4.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,3 @@
-## [0.3.2] / June 13 2024
+## [0.4.0] / June 13 2024
 
-* Upgraded to [Akka v1.5.24](https://github.com/akkadotnet/akka.net/releases/tag/1.5.24)
-* Upgraded to [Akka.Cluster.Hosting v1.5.24](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.24)
-* Upgraded to [Akka.Hosting.TestKit v1.5.24](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.24)
-* Upgraded to [Akka.Management v1.5.24](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.24)
-* Upgraded to [Akka.Discovery.Azure v1.5.24](https://github.com/akkadotnet/Akka.Management/releases/tag/1.5.24)
-* Upgraded to [Akka.HealthCheck v1.5.24](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/1.5.24)
-* Upgraded to [Akka.HealthCheck.Hosting.Web v1.5.24](https://github.com/petabridge/akkadotnet-healthcheck/releases/tag/1.5.24)
-* Upgraded to [Akka.Persistence.Azure.Hosting v1.5.19](https://github.com/petabridge/Akka.Persistence.Azure/releases/tag/1.5.19)
-* Upgraded to [Petabridge.Cmd v1.4.2](https://github.com/petabridge/petabridge.cmd/releases/tag/1.4.2)
-* Upgraded to [Swashbuckle.AspNetCore v6.6.2](https://github.com/akkadotnet/akkadotnet-templates/pull/258)
-* Upgraded to [Microsoft.AspNetCore.OpenApi v8.0.6](https://github.com/akkadotnet/akkadotnet-templates/pull/262)
+* Upgraded all Akka.NET dependenices to [Akka v1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25) in order to avoid [Akka.Logging: v1.5.21 appears to have truncated log source, timestamps, etc from all log messages](https://github.com/akkadotnet/akka.net/issues/7255)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,3 @@
-## [0.4.0] / June 13 2024
+## [0.4.0] / June 19 2024
 
 * Upgraded all Akka.NET dependenices to [Akka v1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25) in order to avoid [Akka.Logging: v1.5.21 appears to have truncated log source, timestamps, etc from all log messages](https://github.com/akkadotnet/akka.net/issues/7255)


### PR DESCRIPTION
## [0.4.0] / June 19 2024

* Upgraded all Akka.NET dependenices to [Akka v1.5.25](https://github.com/akkadotnet/akka.net/releases/tag/1.5.25) in order to avoid [Akka.Logging: v1.5.21 appears to have truncated log source, timestamps, etc from all log messages](https://github.com/akkadotnet/akka.net/issues/7255)