### PR TITLE
added v1.1.0 release notes

### DIFF
--- a/Akka.Templates.csproj
+++ b/Akka.Templates.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <PackageId>Akka.Templates</PackageId>
     <Title>Akka.NET Project Templates</Title>
     <Copyright>Copyright © 2013-2025 Akka.NET Team</Copyright>
     <Authors>AkkaDotNet</Authors>
     <Description>Templates to use when creating new Akka.NET applications.</Description>
     <PackageTags>dotnet-new;templates;akkadotnet;akka;</PackageTags>
-    <PackageReleaseNotes>* Simplified and renamed all Akka.Templates per [https://github.com/akkadotnet/akkadotnet-templates/issues/225](https://github.com/akkadotnet/akkadotnet-templates/issues/225)
-* Upgraded to [Akka.NET v1.5.37](https://github.com/akkadotnet/akka.net/releases/tag/1.5.37)</PackageReleaseNotes>
+    <PackageReleaseNotes>* Added F# template support for the [Akka.Console template](https://github.com/akkadotnet/akkadotnet-templates/blob/dev/docs/ConsoleTemplate.md) - see the docs for an example
+* Upgraded to [Akka.NET v1.5.38](https://github.com/akkadotnet/akka.net/releases/tag/1.5.38)</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-#### 1.0.0 January 23rd 2025 ####
+#### 1.1.0 February 19th 2025 ####
 
-* Simplified and renamed all Akka.Templates per [https://github.com/akkadotnet/akkadotnet-templates/issues/225](https://github.com/akkadotnet/akkadotnet-templates/issues/225)
-* Upgraded to [Akka.NET v1.5.37](https://github.com/akkadotnet/akka.net/releases/tag/1.5.37)
+* Added F# template support for the [Akka.Console template](https://github.com/akkadotnet/akkadotnet-templates/blob/dev/docs/ConsoleTemplate.md) - see the docs for an example
+* Upgraded to [Akka.NET v1.5.38](https://github.com/akkadotnet/akka.net/releases/tag/1.5.38)


### PR DESCRIPTION
#### 1.1.0 February 19th 2025 ####

* Added F# template support for the [Akka.Console template](https://github.com/akkadotnet/akkadotnet-templates/blob/dev/docs/ConsoleTemplate.md) - see the docs for an example
* Upgraded to [Akka.NET v1.5.38](https://github.com/akkadotnet/akka.net/releases/tag/1.5.38)
