### PR TITLE
Add --skip-duplicate flag to NuGet push

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -30,7 +30,7 @@ jobs:
       run:  dotnet pack -c Release -o ./output
 
     - name: Push Packages
-      run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "output/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: release
       uses: actions/create-release@v1


### PR DESCRIPTION
## Summary
Fixes the NuGet publish pipeline to handle cases where a package version already exists on NuGet.

## Problem
The publish pipeline fails with a 409 error when attempting to push a package version that already exists:
```
error: Response status code does not indicate success: 409 (A package with ID 'Akka.Templates' and version '1.3.0' already exists and cannot be modified.).
```

## Solution
Added the `--skip-duplicate` flag to the `dotnet nuget push` command, which skips packages that already exist instead of failing.

## Changes
- Updated `.github/workflows/publish_nuget.yml` to include `--skip-duplicate` flag in the Push Packages step

This allows the pipeline to be idempotent and prevents failures on re-runs or when packages are already published.