### PR TITLE
Bump Akka.NET to 1.5.59

### DIFF
--- a/Akka.Templates.csproj
+++ b/Akka.Templates.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <PackageId>Akka.Templates</PackageId>
     <Title>Akka.NET Project Templates</Title>
     <Copyright>Copyright © 2013-2025 Akka.NET Team</Copyright>
     <Authors>AkkaDotNet</Authors>
     <Description>Templates to use when creating new Akka.NET applications.</Description>
     <PackageTags>dotnet-new;templates;akkadotnet;akka;</PackageTags>
-    <PackageReleaseNotes>* Upgraded Akka.NET dependency to v1.5.55</PackageReleaseNotes>
+    <PackageReleaseNotes>* Upgraded Akka.NET dependency to v1.5.59</PackageReleaseNotes>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.3.1 January 26th 2026 ####
+
+* Upgraded Akka.NET dependency to v1.5.59
+* Upgraded Akka.Hosting dependency to v1.5.59
+
 #### 1.3.0 November 3rd 2025 ####
 
 * Upgraded Akka.NET dependency to v1.5.55

--- a/src/csharp/AkkaConsoleTemplate/AkkaConsoleTemplate.csproj
+++ b/src/csharp/AkkaConsoleTemplate/AkkaConsoleTemplate.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Hosting" Version="1.5.55.1" />
+    <PackageReference Include="Akka.Hosting" Version="1.5.59" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
   </ItemGroup>
 

--- a/src/csharp/AkkaStreamsTemplate/AkkaStreamsTemplate.csproj
+++ b/src/csharp/AkkaStreamsTemplate/AkkaStreamsTemplate.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Hosting" Version="1.5.55.1" />
-    <PackageReference Include="Akka.Streams" Version="1.5.55" />
+    <PackageReference Include="Akka.Hosting" Version="1.5.59" />
+    <PackageReference Include="Akka.Streams" Version="1.5.59" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
   </ItemGroup>
 

--- a/src/csharp/WebApiTemplate/Directory.Packages.props
+++ b/src/csharp/WebApiTemplate/Directory.Packages.props
@@ -5,9 +5,9 @@
 
 
   <PropertyGroup Label="SharedVersions">
-      <AkkaVersion>1.5.55</AkkaVersion>
-      <AkkaHostingVersion>1.5.55.1</AkkaHostingVersion>
-      <AkkaManagementVersion>1.5.55</AkkaManagementVersion>
+      <AkkaVersion>1.5.59</AkkaVersion>
+      <AkkaHostingVersion>1.5.59</AkkaHostingVersion>
+      <AkkaManagementVersion>1.5.59</AkkaManagementVersion>
       <PbmVersion>1.4.4</PbmVersion>
   </PropertyGroup>
 
@@ -18,7 +18,7 @@
     <PackageVersion Include="Akka.Discovery.Azure" Version="$(AkkaManagementVersion)" />
     <PackageVersion Include="Akka.HealthCheck.Hosting.Web" Version="1.5.37" />
     <PackageVersion Include="Akka.Management" Version="$(AkkaManagementVersion)" />
-    <PackageVersion Include="Akka.Persistence.Azure.Hosting" Version="1.5.55" />
+    <PackageVersion Include="Akka.Persistence.Azure.Hosting" Version="1.5.59" />
     <PackageVersion Include="Microsoft.NET.Build.Containers" Version="8.0.200" />
     <PackageVersion Include="Petabridge.Cmd.Cluster.Sharding" Version="$(PbmVersion)" />
     <PackageVersion Include="Petabridge.Cmd.Cluster" Version="$(PbmVersion)" />


### PR DESCRIPTION
Upgrade Akka.NET and Akka.Hosting to 1.5.59

- Update Akka.NET package references to 1.5.59
- Update Akka.Hosting package references to 1.5.59
- Update template version from 1.3.0 to 1.3.1
- Update release notes

References:
- [Akka.NET 1.5.59 Release Notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)
- [Akka.Hosting 1.5.59 Release Notes](https://github.com/akkadotnet/Akka.Hosting/releases/tag/1.5.59)